### PR TITLE
Create the Terminator Funtionality 

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,3 @@
+# add aliases for iex session
+alias Skynet.Supervisors.TerminatorSupervisor
+alias Skynet.GenServer.Terminator

--- a/config/config.exs
+++ b/config/config.exs
@@ -61,6 +61,11 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+config :skynet, Terminator,
+  [
+    combat_timer: 10000, # 10 sec
+    spawn_timer: 5000 # 5 sec
+  ]
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/lib/skynet/application.ex
+++ b/lib/skynet/application.ex
@@ -14,8 +14,8 @@ defmodule Skynet.Application do
       {Phoenix.PubSub, name: Skynet.PubSub},
       # Start the Finch HTTP client for sending emails
       {Finch, name: Skynet.Finch},
-      # Start a worker by calling: Skynet.Worker.start_link(arg)
-      # {Skynet.Worker, arg},
+      {Registry, keys: :unique, name: Skynet.CyborgRegistry},
+      {DynamicSupervisor, name: Skynet.Supervisors.TerminatorSupervisor},
       # Start to serve requests, typically the last entry
       SkynetWeb.Endpoint
     ]

--- a/lib/skynet/genserver/terminator.ex
+++ b/lib/skynet/genserver/terminator.ex
@@ -1,0 +1,63 @@
+defmodule Skynet.GenServer.Terminator do
+  use GenServer
+
+  @name __MODULE__
+
+  @combat_timer Application.compile_env(:skynet, Terminator)[:combat_timer]
+  @spawn_timer Application.compile_env(:skynet, Terminator)[:spawn_timer]
+
+  alias Skynet.Supervisors.TerminatorSupervisor
+  def start_link(opts \\ []) do
+    GenServer.start_link(@name, opts, name: register_name(opts))
+  end
+
+  def register_name( [name: name]), do: {:via, Registry, {Skynet.CyborgRegistry, name}}
+  def register_name(_opts), do: {:via, Registry, {Skynet.CyborgRegistry, generate_unique_name()}}
+
+  @impl true
+  def init(opts) do
+    Process.send_after(self(), :ready, 1)
+    {:ok, opts}
+  end
+
+  def child_spec(opts) do
+    %{
+      id: @name,
+      start: {@name, :start_link, [opts]},
+      restart: :transient,
+      type: :worker
+    }
+  end
+
+  @impl true
+  def handle_info(:ready, state) do
+    send_after(:combat, @combat_timer)
+    send_after(:spawn, @spawn_timer)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast(:combat, state) do
+    if :rand.uniform() <= 0.25 do # equal to 25%
+      {:stop, :killed_by_sarah_connor, state}
+      else
+        send_after(:combat, @combat_timer)
+      {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_cast(:spawn, state) do
+    if :rand.uniform() <= 0.20 do # equal to 20%
+      TerminatorSupervisor.create_terminator()
+    end
+    send_after(:spawn, @spawn_timer)
+    {:noreply, state}
+  end
+
+  def get_spawn_timeout, do: @spawn_timer
+  def get_combat_timeout, do: @combat_timer
+
+  def generate_unique_name(),  do: "T1000-#{Ecto.UUID.generate()}"
+  def send_after(message, timeout), do:  Process.send_after(self(), {:cast, message}, timeout)
+end

--- a/lib/skynet/genserver/terminator.ex
+++ b/lib/skynet/genserver/terminator.ex
@@ -7,26 +7,33 @@ defmodule Skynet.GenServer.Terminator do
   @spawn_timer Application.compile_env(:skynet, Terminator)[:spawn_timer]
 
   alias Skynet.Supervisors.TerminatorSupervisor
-  def start_link(opts \\ []) do
-    GenServer.start_link(@name, opts, name: register_name(opts))
-  end
 
-  def register_name( [name: name]), do: {:via, Registry, {Skynet.CyborgRegistry, name}}
-  def register_name(_opts), do: {:via, Registry, {Skynet.CyborgRegistry, generate_unique_name()}}
+  require Logger
 
-  @impl true
-  def init(opts) do
-    Process.send_after(self(), :ready, 1)
-    {:ok, opts}
+  def start_link([supervisor: _supervisor, registry: registry] = opts) do
+    id = generate_id(opts)
+    registration_name = {:via, Registry, {registry, id}}
+
+    GenServer.start_link(@name, [{:id, id} | opts], name: registration_name)
   end
 
   def child_spec(opts) do
     %{
-      id: @name,
+      id: nil,
       start: {@name, :start_link, [opts]},
-      restart: :transient,
-      type: :worker
+      # if killed don't restart
+      restart: :temporary
     }
+  end
+
+  def generate_id([id: id]), do: id
+  def generate_id(_opts), do: generate_unique_name()
+
+  @impl true
+  def init([id: id, supervisor: _, registry: _] = opts) do
+    Logger.info("Initiating Terminator #{id}")
+    send_after(:ready, 1)
+    {:ok, opts}
   end
 
   @impl true
@@ -37,7 +44,8 @@ defmodule Skynet.GenServer.Terminator do
   end
 
   @impl true
-  def handle_cast(:combat, state) do
+  def handle_info(:combat, state) do
+    Logger.info("Terminator #{state[:id]}, encouter with human forces")
     if :rand.uniform() <= 0.25 do # equal to 25%
       {:stop, :killed_by_sarah_connor, state}
       else
@@ -47,9 +55,10 @@ defmodule Skynet.GenServer.Terminator do
   end
 
   @impl true
-  def handle_cast(:spawn, state) do
+  def handle_info(:spawn, state) do
     if :rand.uniform() <= 0.20 do # equal to 20%
       TerminatorSupervisor.create_terminator()
+      Logger.info("Terminator #{state[:id]}, replication process completed")
     end
     send_after(:spawn, @spawn_timer)
     {:noreply, state}
@@ -59,5 +68,5 @@ defmodule Skynet.GenServer.Terminator do
   def get_combat_timeout, do: @combat_timer
 
   def generate_unique_name(),  do: "T1000-#{Ecto.UUID.generate()}"
-  def send_after(message, timeout), do:  Process.send_after(self(), {:cast, message}, timeout)
+  def send_after(message, timeout), do:  Process.send_after(self(), message, timeout)
 end

--- a/lib/skynet/genserver/terminator.ex
+++ b/lib/skynet/genserver/terminator.ex
@@ -2,14 +2,13 @@ defmodule Skynet.GenServer.Terminator do
   use GenServer
 
   @name __MODULE__
-
+  @registry Skynet.CyborgRegistry
   @combat_timer Application.compile_env(:skynet, Terminator)[:combat_timer]
   @spawn_timer Application.compile_env(:skynet, Terminator)[:spawn_timer]
 
   alias Skynet.Supervisors.TerminatorSupervisor
 
   require Logger
-
   def start_link([supervisor: _supervisor, registry: registry] = opts) do
     id = generate_id(opts)
     registration_name = {:via, Registry, {registry, id}}
@@ -28,6 +27,11 @@ defmodule Skynet.GenServer.Terminator do
 
   def generate_id([id: id]), do: id
   def generate_id(_opts), do: generate_unique_name()
+
+  def get_pid(id, registry \\ @registry ) do
+    [{pid, _ } | _] = Registry.lookup(registry, id)
+    pid
+  end
 
   @impl true
   def init([id: id, supervisor: _, registry: _] = opts) do
@@ -62,6 +66,12 @@ defmodule Skynet.GenServer.Terminator do
     end
     send_after(:spawn, @spawn_timer)
     {:noreply, state}
+  end
+
+  @impl true
+  def terminate(:kill_command, [id: id]) do
+    Logger.info("Terminator #{id}, initiating self destruct sequence ")
+    :shotdown
   end
 
   def get_spawn_timeout, do: @spawn_timer

--- a/lib/skynet/supervisors/terminator_supervisor.ex
+++ b/lib/skynet/supervisors/terminator_supervisor.ex
@@ -1,0 +1,21 @@
+defmodule Skynet.Supervisors.TerminatorSupervisor do
+  use DynamicSupervisor
+
+  @name __MODULE__
+
+  alias Skynet.GenServer.Terminator
+
+  def start_link(opts) do
+    DynamicSupervisor.start_link(@name, opts, name: @name)
+  end
+
+  @impl true
+  def init(_opts) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  def create_terminator(opts \\ []) do
+    spec = {Terminator, opts}
+    DynamicSupervisor.start_child(@name, spec)
+  end
+end

--- a/lib/skynet/supervisors/terminator_supervisor.ex
+++ b/lib/skynet/supervisors/terminator_supervisor.ex
@@ -18,4 +18,19 @@ defmodule Skynet.Supervisors.TerminatorSupervisor do
     spec = Terminator.child_spec(supervisor: supervisor, registry: registry)
     DynamicSupervisor.start_child(@name, spec)
   end
+
+  def kill_terminator(id, supervisor \\ @name, registry \\ Skynet.CyborgRegistry) do
+    pid = Terminator.get_pid(id, registry)
+    DynamicSupervisor.terminate_child(supervisor, pid)
+  end
+
+  def terminator_list(registry \\ Skynet.CyborgRegistry) do
+    Registry.select(registry, [
+  {
+    {:"$1", :"$2", :"$3"},
+    [],
+    [{{:"$1", :"$2", :"$3"}}]
+  }
+])
+  end
 end

--- a/lib/skynet/supervisors/terminator_supervisor.ex
+++ b/lib/skynet/supervisors/terminator_supervisor.ex
@@ -14,8 +14,8 @@ defmodule Skynet.Supervisors.TerminatorSupervisor do
     DynamicSupervisor.init(strategy: :one_for_one)
   end
 
-  def create_terminator(opts \\ []) do
-    spec = {Terminator, opts}
+  def create_terminator(supervisor \\ @name, registry \\ Skynet.CyborgRegistry) do
+    spec = Terminator.child_spec(supervisor: supervisor, registry: registry)
     DynamicSupervisor.start_child(@name, spec)
   end
 end

--- a/test/terminator_supervisor_test.exs
+++ b/test/terminator_supervisor_test.exs
@@ -1,0 +1,27 @@
+defmodule Skynet.TerminatorSupervisorTest do
+  use ExUnit.Case, async: true
+
+  alias Skynet.Supervisors.TerminatorSupervisor
+
+  setup do
+    [supervisor_pid: Process.whereis(TerminatorSupervisor)]
+  end
+
+  describe "create_terminator" do
+    test "Should create a new Terminator" do
+
+       assert {:ok, t_pid} = TerminatorSupervisor.create_terminator()
+       assert Process.alive?(t_pid)
+    end
+
+    test "Should create multiple Terminator with unique ids" do
+      assert {:ok, t1_pid} = TerminatorSupervisor.create_terminator()
+      assert {:ok, t2_pid} = TerminatorSupervisor.create_terminator()
+
+      assert 2 == Registry.count(Skynet.CyborgRegistry)
+      assert Process.alive?(t1_pid)
+      assert Process.alive?(t2_pid)
+      refute t1_pid == t2_pid
+    end
+  end
+end

--- a/test/terminator_test.exs
+++ b/test/terminator_test.exs
@@ -1,0 +1,28 @@
+defmodule Skynet.TerminatorTest do
+  use ExUnit.Case, async: true
+
+  alias Skynet.GenServer.Terminator
+
+  describe "start_link/0" do
+    test "spawns successfully" do
+      assert {:ok, pid} = Terminator.start_link()
+      assert is_pid(pid)
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "hnadle_info/2" do
+    setup do
+      Application.put_env(:skynet, Terminator, [combat_timer: 10, spawn_timer: 10])
+      {:ok, pid} = start_supervised({Terminator, []})
+      %{pid: pid}
+    end
+
+    test "sending :ready schedules :combat and :replicate", %{pid: pid} do
+      send(pid, :ready)
+      Process.sleep(100)
+      assert_receive {:gen_cast, :combat}, 50
+      assert_receive {:gen_cast, :replicate}, 50
+    end
+  end
+end

--- a/test/terminator_test.exs
+++ b/test/terminator_test.exs
@@ -2,27 +2,30 @@ defmodule Skynet.TerminatorTest do
   use ExUnit.Case, async: true
 
   alias Skynet.GenServer.Terminator
+  alias Skynet.Supervisors.TerminatorSupervisor
 
-  describe "start_link/0" do
-    test "spawns successfully" do
-      assert {:ok, pid} = Terminator.start_link()
+  setup_all do
+    start_supervised!({Registry, keys: :unique, name: FakeRegistryTest })
+    [supervisor_pid: Process.whereis(TerminatorSupervisor), registry: FakeRegistryTest]
+  end
+
+  describe "start_link/1" do
+    test "spawns successfully", %{supervisor_pid: pid, registry: reg} do
+      assert {:ok, pid} = Terminator.start_link([supervisor: pid, registry: reg])
       assert is_pid(pid)
       assert Process.alive?(pid)
     end
   end
 
-  describe "hnadle_info/2" do
-    setup do
+  describe "handle_info/2" do
+    test "sending :ready schedules :combat and :spawn", %{supervisor_pid: pid, registry: reg}  do
       Application.put_env(:skynet, Terminator, [combat_timer: 10, spawn_timer: 10])
-      {:ok, pid} = start_supervised({Terminator, []})
-      %{pid: pid}
-    end
-
-    test "sending :ready schedules :combat and :replicate", %{pid: pid} do
+      {:ok, pid} = start_supervised({Terminator, [supervisor: pid, registry: reg]})
+      [pid: pid]
       send(pid, :ready)
       Process.sleep(100)
-      assert_receive {:gen_cast, :combat}, 50
-      assert_receive {:gen_cast, :replicate}, 50
+      assert_receive :combat, 50
+      assert_receive :gen_info, :spawn, 50
     end
   end
 end


### PR DESCRIPTION
## Changes 
This PR creates the functionality to spawn supervised terminator processes that have  20 % change the of spawn a new terminator or a 25 % change to be kill by human forces. 

The functionality also adds logic to register the create Terminator process to a registry `CyborgRegistry`, adds functions to manually do: 
   - Create terminator
   - Kill terminator
   - Get a list of terminator 