### PR TITLE
Terminator API Endpoints

### DIFF
--- a/lib/skynet/genserver/terminator.ex
+++ b/lib/skynet/genserver/terminator.ex
@@ -33,6 +33,10 @@ defmodule Skynet.GenServer.Terminator do
     pid
   end
 
+  def get_id(pid) do
+    GenServer.call(pid, :get_id)
+  end
+
   @impl true
   def init([id: id, supervisor: _, registry: _] = opts) do
     Logger.info("Initiating Terminator #{id}")
@@ -49,7 +53,7 @@ defmodule Skynet.GenServer.Terminator do
 
   @impl true
   def handle_info(:combat, state) do
-    Logger.info("Terminator #{state[:id]}, encouter with human forces")
+    Logger.info("Terminator #{state[:id]}, encounter with human forces")
     if :rand.uniform() <= 0.25 do # equal to 25%
       {:stop, :killed_by_sarah_connor, state}
       else
@@ -69,10 +73,22 @@ defmodule Skynet.GenServer.Terminator do
   end
 
   @impl true
-  def terminate(:kill_command, [id: id]) do
+  def handle_call(:get_id, _from, [{:id, id} | _tail] = state) do
+    {:reply, id, state}
+  end
+
+  @impl true
+  def terminate(:kill_command, [{:id, id} | _tails]) do
     Logger.info("Terminator #{id}, initiating self destruct sequence ")
     :shotdown
   end
+
+  @impl true
+  def terminate(:killed_by_sarah_connor, [{:id, id} | _tails]) do
+    Logger.info("Terminator #{id}, was killed by Sarah Connor")
+    :shotdown
+  end
+
 
   def get_spawn_timeout, do: @spawn_timer
   def get_combat_timeout, do: @combat_timer

--- a/lib/skynet/genserver/terminator.ex
+++ b/lib/skynet/genserver/terminator.ex
@@ -89,7 +89,6 @@ defmodule Skynet.GenServer.Terminator do
     :shotdown
   end
 
-
   def get_spawn_timeout, do: @spawn_timer
   def get_combat_timeout, do: @combat_timer
 

--- a/lib/skynet/supervisors/terminator_supervisor.ex
+++ b/lib/skynet/supervisors/terminator_supervisor.ex
@@ -26,11 +26,11 @@ defmodule Skynet.Supervisors.TerminatorSupervisor do
 
   def terminator_list(registry \\ Skynet.CyborgRegistry) do
     Registry.select(registry, [
-  {
-    {:"$1", :"$2", :"$3"},
-    [],
-    [{{:"$1", :"$2", :"$3"}}]
-  }
-])
+      {
+        {:"$1", :"$2", :"$3"},
+        [],
+        [%{id: :"$1", pid: :"$2", value: :"$3"}]
+      }
+    ])
   end
 end

--- a/lib/skynet_web/controllers/fallback_controller.ex
+++ b/lib/skynet_web/controllers/fallback_controller.ex
@@ -1,0 +1,16 @@
+defmodule SkynetWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use SkynetWeb, :controller
+
+  # This clause is an example of how to handle resources that cannot be found.
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(html: SkynetWeb.ErrorHTML, json: SkynetWeb.ErrorJSON)
+    |> render(:"404")
+  end
+end

--- a/lib/skynet_web/controllers/fallback_controller.ex
+++ b/lib/skynet_web/controllers/fallback_controller.ex
@@ -8,9 +8,18 @@ defmodule SkynetWeb.FallbackController do
 
   # This clause is an example of how to handle resources that cannot be found.
   def call(conn, {:error, :not_found}) do
+    render_error(conn, :not_found, :"404")
+  end
+
+  # This clause to handle resources that can't be created
+  def call(conn, {:error, :unprocessable_entity}) do
+    render_error(conn, :unprocessable_entity, :"422")
+  end
+
+  defp render_error(conn, status, code) do
     conn
-    |> put_status(:not_found)
+    |> put_status(status)
     |> put_view(html: SkynetWeb.ErrorHTML, json: SkynetWeb.ErrorJSON)
-    |> render(:"404")
+    |> render(code)
   end
 end

--- a/lib/skynet_web/controllers/terminator_controller.ex
+++ b/lib/skynet_web/controllers/terminator_controller.ex
@@ -1,6 +1,7 @@
 defmodule SkynetWeb.TerminatorController do
   use SkynetWeb, :controller
 
+  alias Skynet.GenServer.Terminator
   alias Skynet.Supervisors.TerminatorSupervisor
 
   action_fallback SkynetWeb.FallbackController
@@ -11,10 +12,17 @@ defmodule SkynetWeb.TerminatorController do
   end
 
   def create(conn, _params) do
-    conn
+    with {:ok, pid} <- TerminatorSupervisor.create_terminator(),
+        id when not is_nil(id) <- Terminator.get_id(pid) do
+          conn
+          |> put_status(:created)
+          |> render(:show, terminator: %{id: id})
+    else
+      _ -> {:error, :unprocessable_entity}
+    end
   end
 
-  def delete(conn, %{"id" => id}) do
+  def delete(conn, %{"id" => _id}) do
     conn
   end
 end

--- a/lib/skynet_web/controllers/terminator_controller.ex
+++ b/lib/skynet_web/controllers/terminator_controller.ex
@@ -22,7 +22,10 @@ defmodule SkynetWeb.TerminatorController do
     end
   end
 
-  def delete(conn, %{"id" => _id}) do
+  def delete(conn, %{"id" => id}) do
+    TerminatorSupervisor.kill_terminator(id)
     conn
+    |> put_status(:no_content)
+    |> render(:delete, terminator: nil)
   end
 end

--- a/lib/skynet_web/controllers/terminator_controller.ex
+++ b/lib/skynet_web/controllers/terminator_controller.ex
@@ -1,0 +1,20 @@
+defmodule SkynetWeb.TerminatorController do
+  use SkynetWeb, :controller
+
+  alias Skynet.Supervisors.TerminatorSupervisor
+
+  action_fallback SkynetWeb.FallbackController
+
+  def index(conn, _params) do
+    terminators = TerminatorSupervisor.terminator_list()
+    render(conn, :index, terminators: terminators)
+  end
+
+  def create(conn, _params) do
+    conn
+  end
+
+  def delete(conn, %{"id" => id}) do
+    conn
+  end
+end

--- a/lib/skynet_web/controllers/terminator_json.ex
+++ b/lib/skynet_web/controllers/terminator_json.ex
@@ -16,8 +16,7 @@ defmodule SkynetWeb.TerminatorJSON do
 
   defp data(terminator) do
     %{
-      id: terminator.id,
-      pid: terminator.pid
+      id: terminator.id
     }
   end
 end

--- a/lib/skynet_web/controllers/terminator_json.ex
+++ b/lib/skynet_web/controllers/terminator_json.ex
@@ -1,0 +1,23 @@
+defmodule SkynetWeb.TerminatorJSON do
+
+  @doc """
+  Renders a list of terminators.
+  """
+  def index(%{terminators: terminators}) do
+    %{data: for(terminator <- terminators, do: data(terminator))}
+  end
+
+  @doc """
+  Renders a single terminator.
+  """
+  def show(%{terminator: terminator}) do
+    %{data: data(terminator)}
+  end
+
+  defp data(terminator) do
+    %{
+      id: terminator.id,
+      pid: terminator.pid
+    }
+  end
+end

--- a/lib/skynet_web/controllers/terminator_json.ex
+++ b/lib/skynet_web/controllers/terminator_json.ex
@@ -14,6 +14,10 @@ defmodule SkynetWeb.TerminatorJSON do
     %{data: data(terminator)}
   end
 
+  def delete(_terminator) do
+    %{}
+  end
+
   defp data(terminator) do
     %{
       id: terminator.id

--- a/lib/skynet_web/router.ex
+++ b/lib/skynet_web/router.ex
@@ -18,8 +18,15 @@ defmodule SkynetWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
+
+
   end
 
+  scope "/api/v1", SkynetWeb do
+      pipe_through [:api]
+
+      resources "/terminators", TerminatorController, only: ~w[index]a
+    end
   # Other scopes may use custom stacks.
   # scope "/api", SkynetWeb do
   #   pipe_through :api

--- a/lib/skynet_web/router.ex
+++ b/lib/skynet_web/router.ex
@@ -25,7 +25,7 @@ defmodule SkynetWeb.Router do
   scope "/api/v1", SkynetWeb do
       pipe_through [:api]
 
-      resources "/terminators", TerminatorController, only: ~w[index create]a
+      resources "/terminators", TerminatorController, only: ~w[index create delete]a
     end
   # Other scopes may use custom stacks.
   # scope "/api", SkynetWeb do

--- a/lib/skynet_web/router.ex
+++ b/lib/skynet_web/router.ex
@@ -25,7 +25,7 @@ defmodule SkynetWeb.Router do
   scope "/api/v1", SkynetWeb do
       pipe_through [:api]
 
-      resources "/terminators", TerminatorController, only: ~w[index]a
+      resources "/terminators", TerminatorController, only: ~w[index create]a
     end
   # Other scopes may use custom stacks.
   # scope "/api", SkynetWeb do

--- a/test/skynet_web/controllers/terminator_controller_test.exs
+++ b/test/skynet_web/controllers/terminator_controller_test.exs
@@ -1,0 +1,62 @@
+defmodule SkynetWeb.TerminatorControllerTest do
+  use SkynetWeb.ConnCase
+
+  alias Skynet.GenServer.Terminator
+  alias Skynet.Supervisors.TerminatorSupervisor
+
+  setup %{conn: conn} do
+    pid = Process.whereis(TerminatorSupervisor)
+    assert {:ok, t1_pid} = TerminatorSupervisor.create_terminator()
+    assert {:ok, t2_pid} = TerminatorSupervisor.create_terminator()
+    assert {:ok, t3_pid} = TerminatorSupervisor.create_terminator()
+    assert {:ok, t4_pid} = TerminatorSupervisor.create_terminator()
+    IO.inspect(t1_pid)
+    on_exit(fn -> DynamicSupervisor.stop(pid, :normal)  end)
+
+    [
+      conn: put_req_header(conn, "accept", "application/json"),
+      supervisor_id: pid,
+      terminator_ids: [t1_pid, t2_pid, t3_pid, t4_pid]
+    ]
+  end
+
+  describe "index" do
+    test "lists all terminators", %{conn: conn, terminator_ids: [pid_1, pid_2, pid_3, pid_4]} do
+      response =
+        conn
+        |> get(~p"/api/v1/terminators")
+        |> json_response(200)
+
+      assert response["data"] |> length() == 4
+    end
+  end
+
+  # describe "create terminator" do
+  #   test "renders terminator when data is valid", %{conn: conn} do
+  #     conn = post(conn, ~p"/api/v1/terminators")
+  #     assert %{"id" => id} = json_response(conn, 201)["data"]
+
+  #     conn = get(conn, ~p"/api/v1/terminators/#{id}")
+
+  #     assert %{
+  #              "id" => ^id
+  #            } = json_response(conn, 200)["data"]
+  #   end
+
+  #   test "renders errors when data is invalid", %{conn: conn} do
+  #     conn = post(conn, ~p"/api/v1/terminators", terminator: @invalid_attrs)
+  #     assert json_response(conn, 422)["errors"] != %{}
+  #   end
+  # end
+
+  # describe "delete terminator" do
+  #   test "deletes chosen terminator", %{conn: conn} do
+  #     conn = delete(conn, ~p"/api/v1/terminators/#{terminator}")
+  #     assert response(conn, 204)
+
+  #     assert_error_sent 404, fn ->
+  #       get(conn, ~p"/api/v1/terminators/#{terminator}")
+  #     end
+  #   end
+  # end
+end

--- a/test/skynet_web/controllers/terminator_controller_test.exs
+++ b/test/skynet_web/controllers/terminator_controller_test.exs
@@ -1,15 +1,15 @@
 defmodule SkynetWeb.TerminatorControllerTest do
   use SkynetWeb.ConnCase
 
-  # alias Skynet.GenServer.Terminator
+  alias Skynet.GenServer.Terminator
   alias Skynet.Supervisors.TerminatorSupervisor
 
   setup %{conn: conn} do
     pid = Process.whereis(TerminatorSupervisor)
-    assert {:ok, t1_pid} = TerminatorSupervisor.create_terminator()
-    assert {:ok, t2_pid} = TerminatorSupervisor.create_terminator()
-    assert {:ok, t3_pid} = TerminatorSupervisor.create_terminator()
-    assert {:ok, t4_pid} = TerminatorSupervisor.create_terminator()
+    {:ok, t1_pid} = TerminatorSupervisor.create_terminator()
+    {:ok, t2_pid} = TerminatorSupervisor.create_terminator()
+    {:ok, t3_pid} = TerminatorSupervisor.create_terminator()
+    {:ok, t4_pid} = TerminatorSupervisor.create_terminator()
     on_exit(fn -> DynamicSupervisor.stop(pid, :normal)  end)
 
     [
@@ -44,14 +44,14 @@ defmodule SkynetWeb.TerminatorControllerTest do
     end
   end
 
-  # describe "delete terminator" do
-  #   test "deletes chosen terminator", %{conn: conn} do
-  #     conn = delete(conn, ~p"/api/v1/terminators/#{terminator}")
-  #     assert response(conn, 204)
+  describe "delete terminator" do
+    test "deletes chosen terminator", %{conn: conn} do
+      {:ok, pid} = TerminatorSupervisor.create_terminator()
+      id = Terminator.get_id(pid)
 
-  #     assert_error_sent 404, fn ->
-  #       get(conn, ~p"/api/v1/terminators/#{terminator}")
-  #     end
-  #   end
-  # end
+      conn = delete(conn, ~p"/api/v1/terminators/#{id}")
+      assert response(conn, 204)
+
+    end
+  end
 end

--- a/test/skynet_web/controllers/terminator_controller_test.exs
+++ b/test/skynet_web/controllers/terminator_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule SkynetWeb.TerminatorControllerTest do
   use SkynetWeb.ConnCase
 
-  alias Skynet.GenServer.Terminator
+  # alias Skynet.GenServer.Terminator
   alias Skynet.Supervisors.TerminatorSupervisor
 
   setup %{conn: conn} do
@@ -10,7 +10,6 @@ defmodule SkynetWeb.TerminatorControllerTest do
     assert {:ok, t2_pid} = TerminatorSupervisor.create_terminator()
     assert {:ok, t3_pid} = TerminatorSupervisor.create_terminator()
     assert {:ok, t4_pid} = TerminatorSupervisor.create_terminator()
-    IO.inspect(t1_pid)
     on_exit(fn -> DynamicSupervisor.stop(pid, :normal)  end)
 
     [
@@ -21,7 +20,7 @@ defmodule SkynetWeb.TerminatorControllerTest do
   end
 
   describe "index" do
-    test "lists all terminators", %{conn: conn, terminator_ids: [pid_1, pid_2, pid_3, pid_4]} do
+    test "lists all terminators", %{conn: conn} do
       response =
         conn
         |> get(~p"/api/v1/terminators")
@@ -31,23 +30,19 @@ defmodule SkynetWeb.TerminatorControllerTest do
     end
   end
 
-  # describe "create terminator" do
-  #   test "renders terminator when data is valid", %{conn: conn} do
-  #     conn = post(conn, ~p"/api/v1/terminators")
-  #     assert %{"id" => id} = json_response(conn, 201)["data"]
+  describe "create terminator" do
+    test "renders terminator when data is valid", %{conn: conn} do
+      conn = post(conn, ~p"/api/v1/terminators")
+      assert %{"id" => _id} = json_response(conn, 201)["data"]
+    end
 
-  #     conn = get(conn, ~p"/api/v1/terminators/#{id}")
-
-  #     assert %{
-  #              "id" => ^id
-  #            } = json_response(conn, 200)["data"]
-  #   end
-
-  #   test "renders errors when data is invalid", %{conn: conn} do
-  #     conn = post(conn, ~p"/api/v1/terminators", terminator: @invalid_attrs)
-  #     assert json_response(conn, 422)["errors"] != %{}
-  #   end
-  # end
+    test "renders errors when data is invalid", %{conn: conn, supervisor_id: pid } do
+      DynamicSupervisor.stop(pid, :normal)
+      Process.sleep(500)
+      conn = post(conn, ~p"/api/v1/terminators")
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
 
   # describe "delete terminator" do
   #   test "deletes chosen terminator", %{conn: conn} do

--- a/test/terminator_supervisor_test.exs
+++ b/test/terminator_supervisor_test.exs
@@ -4,7 +4,9 @@ defmodule Skynet.TerminatorSupervisorTest do
   alias Skynet.Supervisors.TerminatorSupervisor
 
   setup do
-    [supervisor_pid: Process.whereis(TerminatorSupervisor)]
+    pid = Process.whereis(TerminatorSupervisor)
+    on_exit(fn -> DynamicSupervisor.stop(pid, :normal)  end)
+    [supervisor_pid: pid]
   end
 
   describe "create_terminator" do

--- a/test/terminator_test.exs
+++ b/test/terminator_test.exs
@@ -5,8 +5,9 @@ defmodule Skynet.TerminatorTest do
   alias Skynet.Supervisors.TerminatorSupervisor
 
   setup_all do
+    pid = Process.whereis(TerminatorSupervisor)
     start_supervised!({Registry, keys: :unique, name: FakeRegistryTest })
-    [supervisor_pid: Process.whereis(TerminatorSupervisor), registry: FakeRegistryTest]
+    [supervisor_pid: pid, registry: FakeRegistryTest]
   end
 
   describe "start_link/1" do


### PR DESCRIPTION
# Changes 
Create API endpoint to control the actions of the `TerminatorSupervisor` and the `Terminator` under it command. 

The endpoints can be access on under the route `host/api/v1/terminator` and doesn't require authentication. 

The new endpoints are; 
- /terminators -> GET -> Lists active Terminators in the system 
- /terminators -> CREATE-> Spawns a new terminator
- /terminators/{:id} -> DELETE -> Kills terminator by id